### PR TITLE
fix(package.json): Could not find a declaration file for module.

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "type": "module",
   "exports": {
     "require": "./lib/react-leaflet-marker.cjs",
-    "default": "./lib/react-leaflet-marker.modern.js"
+    "default": "./lib/react-leaflet-marker.modern.js",
+    "types": "./lib/index.d.ts"
   },
   "main": "lib/react-leaflet-marker.cjs",
   "module": "lib/react-leaflet-marker.module.js",

--- a/package.json
+++ b/package.json
@@ -5,9 +5,9 @@
   "source": "src/index.ts",
   "type": "module",
   "exports": {
+    "types": "./lib/index.d.ts",
     "require": "./lib/react-leaflet-marker.cjs",
-    "default": "./lib/react-leaflet-marker.modern.js",
-    "types": "./lib/index.d.ts"
+    "default": "./lib/react-leaflet-marker.modern.js"
   },
   "main": "lib/react-leaflet-marker.cjs",
   "module": "lib/react-leaflet-marker.module.js",


### PR DESCRIPTION
Added a new `types` key inside `exports` on `package.json` to fix the following:

Could not find a declaration file for module `'react-leaflet-marker'`.

`/node_modules/.pnpm/react-leaflet-marker@2.1.0_react-dom@18.2.0_react-leaflet@4.2.1_react@18.2.0/node_modules/react-leaflet-marker/lib/react-leaflet-marker.modern.js` implicitly has an `any` type.

There are types at `/node_modules/react-leaflet-marker/lib/index.d.ts`, but this result could not be resolved when respecting package.json `exports`. The 'react-leaflet-marker' library may need to update its package.json or typings.

[TS 7016](https://typescript.tv/errors/#ts7016)