### PR TITLE
Build/optimize bundle size

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
   "peerDependencies": {
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "react-leaflet": "^4.2.0"
+    "react-leaflet": "^4.2.0",
+    "leaflet": "^1.8.0"
   },
   "devDependencies": {
     "@babel/preset-react": "^7.16.7",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "type": "module",
   "exports": {
     "require": "./lib/react-leaflet-marker.cjs",
-    "default": "./lib/react-leaflet-marker.modern.js"
+    "default": "./lib/react-leaflet-marker.modern.js",
+    "types": "./lib/index.d.ts"
   },
   "main": "lib/react-leaflet-marker.cjs",
   "module": "lib/react-leaflet-marker.module.js",

--- a/package.json
+++ b/package.json
@@ -5,9 +5,9 @@
   "source": "src/index.ts",
   "type": "module",
   "exports": {
+    "types": "./lib/index.d.ts",
     "require": "./lib/react-leaflet-marker.cjs",
-    "default": "./lib/react-leaflet-marker.modern.js",
-    "types": "./lib/index.d.ts"
+    "default": "./lib/react-leaflet-marker.modern.js"
   },
   "main": "lib/react-leaflet-marker.cjs",
   "module": "lib/react-leaflet-marker.module.js",


### PR DESCRIPTION
Added leaflet as peerDependency so we can save 42 kB, microbundle seems to be smart enough to look at the peers and it won't include it in the build files.

Also code from https://github.com/holytrips/react-leaflet-marker/pull/14 is on this branch.

Hopefully you will look at it :)